### PR TITLE
Add symlink for Python 3.12 versioned file

### DIFF
--- a/public/3.12/virtualenv.pyz
+++ b/public/3.12/virtualenv.pyz
@@ -1,0 +1,1 @@
+../virtualenv.pyz


### PR DESCRIPTION
So that the versioned download URL works for Python 3.12 too:
https://bootstrap.pypa.io/virtualenv/3.12/virtualenv.pyz

Fixes pypa/virtualenv#2744.

xref python-poetry/install.python-poetry.org#142 and moneymeets/python-poetry-buildpack#71.