### PR TITLE
Publish virtualenv.pyz to github releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,20 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Upload virtualenv.pyz to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./public/virtualenv.pyz
-          asset_name: virtualenv.pyz
-          asset_content_type: application/octet-stream
+        run: |
+          upload_url=${{ github.event.release.upload_url }}
+
+          # Remove the template bit at the end
+          upload_url="${upload_url%\{*\}}"
+          # add the asset name
+          upload_url="${upload_url}?name=virtualenv.pyz"
+
+          curl -L --fail-with-body \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Content-Type: application/octet-stream" \
+            "${upload_url}" \
+            --data-binary "@public/virtualenv.pyz"
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Upload virtualenv.pyz to release
+
+on:
+  release:
+    types: [published]
+
+# Sets the permissions for GITHUB_TOKEN to allow writing to releases
+permissions:
+  contents: write
+
+jobs:
+  upload-asset:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Upload virtualenv.pyz to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./public/virtualenv.pyz
+          asset_name: virtualenv.pyz
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,36 +1,29 @@
-name: Upload virtualenv.pyz to release
+name: Create Release on Version Change
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
+    paths:
+      - 'public/version.txt'
 
-# Sets the permissions for GITHUB_TOKEN to allow writing to releases
 permissions:
   contents: write
 
 jobs:
-  upload-asset:
-    runs-on: ubuntu-latest
+  create-release:
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
-      - name: Upload virtualenv.pyz to release
-        run: |
-          upload_url=${{ github.event.release.upload_url }}
+      - name: Read version from file
+        id: get_version
+        run: echo "version=$(cat public/version.txt)" >> $GITHUB_OUTPUT
 
-          # Remove the template bit at the end
-          upload_url="${upload_url%\{*\}}"
-          # add the asset name
-          upload_url="${upload_url}?name=virtualenv.pyz"
-
-          curl -L --fail-with-body \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            -H "Content-Type: application/octet-stream" \
-            "${upload_url}" \
-            --data-binary "@public/virtualenv.pyz"
-
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.get_version.outputs.version }}
+          files: public/virtualenv.pyz


### PR DESCRIPTION
See #51. 

Regarding the implementation, there is an 'official' github action for uploading release assets, but it's deprecated. Most people seem to use a 3rd-party action instead, but I wasn't sure about the security implications of a 3rd-party dep in the release process. Instead, I implemented it in 3 lines of bash. I hope that works for you!